### PR TITLE
ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,27 +73,11 @@ jobs:
         run: |
           mkdir dist
           cabal install exe:part5 --install-method=copy --overwrite-policy=always --installdir=dist
-
-      - name: Set binary path name
-        run: echo "BINARY_PATH=./dist/part5" >> $GITHUB_ENV
-
-      - name: Load release URL file from release job
-        uses: actions/download-artifact@v3
-        with:
-          name: release_url
-
-      - name: Get release file name and upload URL
-        id: get_release_info
-        run: |
-          echo "upload_url=$(cat release_url/release_url.txt)" >> $GITHUB_OUTPUT
+          mv dist/part5 part5-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}
 
       - name: Upload release asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
+        uses: softprops/action-gh-release@v1
+        with:
+          files: part5-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ${{ env.BINARY_PATH }}
-          asset_name: part5-${{ steps.tag.outputs.tag }}-${{ runner.os }}-ghc-${{ matrix.ghc }}
-          asset_content_type: application/octet-stream


### PR DESCRIPTION
- ci: try to migrate away from deprecated ::set-* commands in release workflow
- ci: remove compression step, as it fails locally with act
- ci: use softprops/action-gh-release instead of deprecated upload-release-asset
