### PR TITLE
ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, These users will be requested for review when
+# someone opens a pull request.
+
+*        @symbiont-stevan-andjelkovic @symbiont-daniel-gustafsson

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,14 +27,6 @@ jobs:
           draft: true
           prerelease: false
 
-      - name: Output release URL file
-        run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
-      - name: Save release URL file for publish
-        uses: actions/upload-artifact@v3
-        with:
-          name: release_url
-          path: release_url.txt
-
   build_artifact:
     needs: [create_release]
     name: ${{ matrix.os }}/GHC ${{ matrix.ghc }}/${{ github.ref }}


### PR DESCRIPTION
- ci: try to migrate away from deprecated ::set-* commands in release workflow
- ci: remove compression step, as it fails locally with act
- ci: use softprops/action-gh-release instead of deprecated upload-release-asset
- ci: remove unnecessary release step and add codeowners
