### PR TITLE
more

### DIFF
--- a/src/Part01SMTesting.lhs
+++ b/src/Part01SMTesting.lhs
@@ -123,7 +123,7 @@ i_3 >` is the counterexample we present.
 Regression testing
 ------------------
 
-If we find a sequence of inputs that cause a failure, we might want to save that
+If we find a sequence of inputs that causes a failure, we might want to save that
 test case as a regression test. It can be helpful to think of a regression test
 as a path through a (different from the shrinking) tree:
 
@@ -448,6 +448,21 @@ inspiration of small stuff to play with.
 0. If you're not comfortable with Haskell, port the above code to your favorite
    programming language.
 
+   The difficulty of this will vary greatly depending on what your favorite
+   language is, how good clone of the `QuickCheck` PBT library the language has,
+   and how comfortable you are with understanding the above Haskell code in the
+   first place. We'd therefore like to encourage people who have successfuly
+   done this excerise to let us know of suitable languages and PBT libraries for
+   this task! We'll list them here, so that people who are unsure don't embark
+   on an potentially impossible task.
+
+   As a further note of warning: some PBT libraries in some languages have an
+   API very different from `QuickCheck`, but are still capable of writing the
+   tests we did here. However their APIs might not be able to do concurrent
+   testing like we will do in part 2 and later, for example Go's
+   [`gopter`](https://pkg.go.dev/github.com/leanovate/gopter) and
+   [`rapid`](https://github.com/flyingmutant/rapid) libraries.
+
 1. Run the `prop_counter` property, perhaps using `withMaxSuccess` to adjust the
    number of test cases generated, in order to trigger a bug that we've hidden
    somewhere in the SUT. Fix the bug and ensure that tests pass.
@@ -483,6 +498,13 @@ inspiration of small stuff to play with.
 
 8. Collect timing information about how long each command takes to execute on
    average.
+
+9. Some systems might have inputs which generate resources which later inputs
+   can depend on, e.g. the unix filesystem syscall `open` returns a file
+   descriptor which can later be passed to `read` or `write`. Figure out how to
+   model such systems (hint: see how `Reference`s are used in the
+   [`quickcheck-state-machine`](https://github.com/stevana/quickcheck-state-machine#readme)
+   library).
 
 See also
 --------

--- a/src/Part02ConcurrentSMTesting.lhs
+++ b/src/Part02ConcurrentSMTesting.lhs
@@ -52,7 +52,7 @@ by concurrent.
 
 One such concurrent history can have different interleavings, depending on when
 exactly the effect of the commands happen. Here are two possible interleavings,
-where the red cross symbolises when the effect happend.
+where the red cross symbolises when the effect happened.
 
 The first corresponds to the sequential history `< incr 1, get, incr 2, get >`:
 


### PR DESCRIPTION
- feat(part2): clearify a few previous things and add more text
- feat(part2): expand on regression testing and discussion
- feat(part2): add note about linearisability being a local property
- Update docs/Part02ConcurrentSMTesting.md
- feat(part2): add linearisabilty checking exercise
- refactor(part2): fix formatting of linearisability check exercise
- feat(part2): remove under construction sign
- feat(part3): turn motivation into a proper text
- refactor(part3): don't call contract tests a standard solution
- fix(part1, part2): typos and add warning about porting excersise
